### PR TITLE
Replace relative import with absolute one

### DIFF
--- a/statistic_test.go
+++ b/statistic_test.go
@@ -1,7 +1,7 @@
 package skyline_test
 
 import (
-	"../skyline"
+	"github.com/datastream/skyline"
 	"testing"
 )
 


### PR DESCRIPTION
Relative imports break tools like dep (https://github.com/golang/dep/issues/899)
and they're in general not recommended to be used.