### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -15,7 +15,7 @@ func TimeArray(timeseries []TimePoint) []int64 {
 	return t
 }
 
-// TimeArray return all timestamps in timeseries array
+// TimeArray64 return all timestamps in timeseries array
 func TimeArray64(timeseries []TimePoint) []float64 {
 	var t []float64
 	for _, val := range timeseries {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?